### PR TITLE
[base-files] Fix fstab overriding

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,9 +1,1 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/base-files:"
-
-SRC_URI += " \
-	file://fstab \
-"
-
-do_install_append () {
-	install -m 0644 ${WORKDIR}/fstab ${D}${sysconfdir}/fstab
-}
+FILESEXTRAPATHS_append := "${THISDIR}/base-files:"


### PR DESCRIPTION
To properly put custom fstab on the rootfs we have to append only folder
where the new fstab is located. During install base-files, yocto will take
custom fstab file instead of default one.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>