### PR TITLE
Alias for loopback interface

### DIFF
--- a/doc/aos_board.cfg
+++ b/doc/aos_board.cfg
@@ -1,0 +1,21 @@
+{
+    "resources": [
+        {
+            "name": "vis",
+            "hosts": [
+                {
+                    "ip": "10.0.0.7",
+                    "hostname": "wwwivi"
+                }
+            ]
+        }
+    ],
+    "components": [
+        {
+            "id": "rootfs"
+        },
+        {
+            "id": "boot"
+        }
+    ]
+}

--- a/recipes-extended/netconfig/files/lo.1.network
+++ b/recipes-extended/netconfig/files/lo.1.network
@@ -1,0 +1,6 @@
+[Match]
+Name=lo
+
+[Address]
+Label=lo:1
+Address=10.0.0.7/24

--- a/recipes-extended/netconfig/netconfig.bb
+++ b/recipes-extended/netconfig/netconfig.bb
@@ -7,6 +7,7 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 
 SRC_URI += "\
     file://eth.network \
+    file://lo.1.network \
 "
 
 do_install_append() {


### PR DESCRIPTION
Adding alias(lo:1) for loopback interface with 10.0.0.7/24 address, via adding localalias.network file to systemd/network folder.