### PR TITLE
[dnsmasq] Install only dnsmasq binary

### DIFF
--- a/recipes-support/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-support/dnsmasq/dnsmasq_%.bbappend
@@ -1,3 +1,11 @@
-# disable dnsmasq daemon
+# disable dnsmasq daemon and install binary only
 
+do_install () {
+	oe_runmake "PREFIX=${D}${prefix}" \
+               "BINDIR=${D}${bindir}" \
+               "MANDIR=${D}${mandir}" \
+               install
+}
+
+SYSTEMD_SERVICE_${PN} = ""
 SYSTEMD_AUTO_ENABLE ?= "disable"


### PR DESCRIPTION
The aos-dnsname plugin uses dnsmasq binary directly, so additional
configs and init files are not needed.

Signed-off-by: Leonid Komarianskyi <leonid_komarianskyi@epam.com>