### PR TITLE
[iam] Fix pin generation in the encrypt script

### DIFF
--- a/recipes-aos/aos-iamanager/files/encrypt.sh
+++ b/recipes-aos/aos-iamanager/files/encrypt.sh
@@ -2,7 +2,7 @@
 
 PIN=$(cat /var/.usrpin.txt)
 
-PASSWORD="$(dd if=/dev/urandom bs=10 count=1)"
+PASSWORD="$(cat /dev/urandom | base64 | head -c 10)"
 
 echo PIN=$PIN > /var/.usrpin;
 


### PR DESCRIPTION
Sometimes, provisioning can be failed in the case
if the first byte from urandom is '0'.

Signed-off-by: Leonid Komarianskyi <leonid_komarianskyi@epam.com>