### PR TITLE
[aos-image-vm] Remove protobuf packages from toolchain

### DIFF
--- a/meta-aos-vm-common/recipes-core/images/aos-image-vm.bb
+++ b/meta-aos-vm-common/recipes-core/images/aos-image-vm.bb
@@ -32,5 +32,3 @@ IMAGE_INSTALL:append = " \
 IMAGE_ROOTFS_SIZE ?= "1048576"
 IMAGE_OVERHEAD_FACTOR ?= "1.0"
 IMAGE_ROOTFS_EXTRA_SPACE ?= "524288"
-
-TOOLCHAIN_HOST_TASK:append = " nativesdk-protobuf nativesdk-protobuf-dev nativesdk-grpc nativesdk-grpc-compiler"


### PR DESCRIPTION
Moved to meta-aos.