### PR TITLE
yaml: use machine prefix for fota artifacts

### DIFF
--- a/aos-vm.yaml
+++ b/aos-vm.yaml
@@ -223,7 +223,7 @@ components:
       script: "../yocto/meta-aos/scripts/fota_builder.py"
       args: "-v"
       target_images:
-        - "../output/fota/%{AOS_NODE_TYPE}-fota-full-%{BUNDLE_IMAGE_VERSION}.tar"
+        - "../output/fota/%{AOS_NODE_TYPE}-fota-full-%{MACHINE}-%{BUNDLE_IMAGE_VERSION}.tar"
 
       additional_deps:
         - "%{YOCTOS_WORK_DIR}/build-%{NODE_TYPE}/tmp/deploy/images/%{MACHINE}/%{AOS_BASE_IMAGE}-%{MACHINE}.rootfs.ext4"
@@ -274,7 +274,7 @@ components:
       script: "../yocto/meta-aos/scripts/fota_builder.py"
       args: "-v"
       target_images:
-        - "../output/fota/%{AOS_NODE_TYPE}-fota-incremental-%{BUNDLE_IMAGE_VERSION}.tar"
+        - "../output/fota/%{AOS_NODE_TYPE}-fota-incremental-%{MACHINE}-%{BUNDLE_IMAGE_VERSION}.tar"
 
       additional_deps:
         - "%{YOCTOS_WORK_DIR}/build-%{NODE_TYPE}/tmp/deploy/images/%{MACHINE}/%{AOS_BASE_IMAGE}-%{MACHINE}.rootfs.ext4"


### PR DESCRIPTION
This patch prevents conflicts on CI, when multiple machine targets are built: all of the FOTA artifacts will be prefixed with the machine name.