### PR TITLE
recipes-aos: update root cert path in Aos configs

### DIFF
--- a/meta-aos-vm-main/recipes-aos/aos-iamanager/files/iam.cfg
+++ b/meta-aos-vm-main/recipes-aos/aos-iamanager/files/iam.cfg
@@ -1,5 +1,5 @@
 {
-    "caCert": "/etc/ssl/certs/Aos_Root_CA.pem",
+    "caCert": "/usr/share/ca-certificates/aos/AosRootCA.crt",
     "certStorage": "iam",
     "iamProtectedServerUrl": ":8089",
     "iamPublicServerUrl": ":8090",

--- a/meta-aos-vm-main/recipes-aos/aos-servicemanager/files/sm.cfg
+++ b/meta-aos-vm-main/recipes-aos/aos-servicemanager/files/sm.cfg
@@ -1,5 +1,5 @@
 {
-    "caCert": "/etc/ssl/certs/Aos_Root_CA.pem",
+    "caCert": "/usr/share/ca-certificates/aos/AosRootCA.crt",
     "certStorage": "sm",
     "iamProtectedServerUrl": "aosiam:8089",
     "iamPublicServerUrl": "aosiam:8090",

--- a/meta-aos-vm-node/recipes-aos/aos-iamanager/files/iam.cfg
+++ b/meta-aos-vm-node/recipes-aos/aos-iamanager/files/iam.cfg
@@ -1,5 +1,5 @@
 {
-    "caCert": "/etc/ssl/certs/Aos_Root_CA.pem",
+    "caCert": "/usr/share/ca-certificates/aos/AosRootCA.crt",
     "certStorage": "iam",
     "mainIamPublicServerUrl": "main:8090",
     "mainIamProtectedServerUrl": "main:8089",

--- a/meta-aos-vm-node/recipes-aos/aos-servicemanager/files/sm.cfg
+++ b/meta-aos-vm-node/recipes-aos/aos-servicemanager/files/sm.cfg
@@ -1,5 +1,5 @@
 {
-    "caCert": "/etc/ssl/certs/Aos_Root_CA.pem",
+    "caCert": "/usr/share/ca-certificates/aos/AosRootCA.crt",
     "certStorage": "sm",
     "iamProtectedServerUrl": "aosiam:8089",
     "iamPublicServerUrl": "aosiam:8090",


### PR DESCRIPTION
As Aos root cert location was changed to /usr/share/ca-certificates/aos, update Aos configs accordingly.