### PR TITLE
yaml: remove domain from layers and fota metadata

### DIFF
--- a/aos-vm.yaml
+++ b/aos-vm.yaml
@@ -210,7 +210,6 @@ components:
 
         publish:
           tlsKey: "aos-user-oem.p12"
-          domain: "aoscloud.io"
 
         yocto_dir: "../%{YOCTOS_WORK_DIR}"
         build_dir: "build-%{NODE_TYPE}"
@@ -249,7 +248,6 @@ components:
 
         publish:
           tlsKey: "aos-user-oem.p12"
-          domain: "aoscloud.io"
 
         work_dir: "workdir"
         items:


### PR DESCRIPTION
If domain is not specified in metadata, aos-signer takes domain from current certificate. It allows to use same metadata file to deploy to different url based on the current user certificate.