### PR TITLE
kernel: enable nftables and tc for native SM networking

### DIFF
--- a/meta-aos-vm-common/recipes-kernel/linux/files/common_node.cfg
+++ b/meta-aos-vm-common/recipes-kernel/linux/files/common_node.cfg
@@ -7,9 +7,22 @@ CONFIG_CFS_BANDWIDTH=y
 CONFIG_CMDLINE_BOOL=y
 CONFIG_CMDLINE="cgroup_no_v1=all systemd.unified_cgroup_hierarchy=1"
 
-# Enable required netfilter for CNI plugins (iptables)
+# nftables stack (replaces iptables)
 
-CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=m
+CONFIG_NF_TABLES=y
+CONFIG_NF_TABLES_INET=y
+CONFIG_NF_CONNTRACK=m
+CONFIG_NF_NAT=m
+CONFIG_NFT_CT=m
+CONFIG_NFT_NAT=m
+CONFIG_NFT_MASQ=m
+
+# tc bandwidth (ingress -> IFB mirred redirect)
+
+CONFIG_NET_SCH_TBF=m
+CONFIG_NET_SCH_INGRESS=m
+CONFIG_NET_ACT_MIRRED=m
+CONFIG_NET_CLS_MATCHALL=m
 
 # Enable vxlan interface
 


### PR DESCRIPTION
Pin the nftables and tc bandwidth options the service manager's native networking stack needs, and drop the iptables-only addrtype match.