### PR TITLE
redis: disable snapshots in redis.conf

### DIFF
--- a/aos-vm.yaml
+++ b/aos-vm.yaml
@@ -469,7 +469,7 @@ images:
       aos:
         gpt_type: CA7D7CCB-63ED-4C53-861C-1742536059CC # LUKS partition
         type: empty
-        size: 16384 MiB
+        size: 32768 MiB
 
 parameters:
   MACHINE:

--- a/meta-aos-vm-common/recipes-extended/redis/redis_%.bbappend
+++ b/meta-aos-vm-common/recipes-extended/redis/redis_%.bbappend
@@ -1,4 +1,6 @@
 do_install:append() {
     sed -i 's/^bind 127.0.0.1$/bind 127.0.0.1 10.0.0.100/' ${D}${sysconfdir}/redis/redis.conf
     sed -i 's/^# requirepass foobared$/requirepass mypassword/' ${D}${sysconfdir}/redis/redis.conf
+    sed -i 's/^save/#save/' ${D}${sysconfdir}/redis/redis.conf
+    sed -i '/^stop-writes-on-bgsave-error/s/yes/no/' ${D}${sysconfdir}/redis/redis.conf
 }


### PR DESCRIPTION
This patch disables snapshots in redis.conf by
commenting out the "save" directive.
This is to prevent Redis from persisting data to disk, otherwise long running Redis instances may consume a lot of disk space and fill up var partition.